### PR TITLE
Perform HEAD instead of GET for HEAD

### DIFF
--- a/resty
+++ b/resty
@@ -63,7 +63,7 @@ function resty() {
       [ -n "$dat" ] && [ "$dat" != "@-" ] && shift
       [ "$1" = "-Z" ] && raw="yes" && shift
       [ -n "$dat" ] && opt="--data-binary"
-      [ "$method" = "HEAD" ] && method="GET" && opt="-I" && raw="yes"
+      [ "$method" = "HEAD" ] && opt="-I" && raw="yes"
       [ "$method" = "OPTIONS" ] && opt="-I" && raw="yes"
       eval "args2=( $(cat "$confdir/$domain" 2>/dev/null |sed 's/^ *//' |grep ^$method |cut -b $((${#method}+2))-) )"
       res=$((((curl -sLv $opt "$dat" -X $method \


### PR DESCRIPTION
HEAD requests are sometimes handled differently from GETs so the distinction can be important.
