### PR TITLE
Allowing PUT / POST without request body data

### DIFF
--- a/resty
+++ b/resty
@@ -52,7 +52,7 @@ function resty() {
     HEAD|OPTIONS|GET|DELETE|POST|PUT|TRACE)
       dat=$( ( [ "$hasdata" = "yes" ] \
         && ( ( [ -n "$1" ] && [ "${1#-}" = "$1" ] && echo "$1") \
-        || echo "@-") ) || echo)
+        || [ ! -t 0 ] && echo "@-") ) || echo)
       if [ "$hasdata" = "yes" ] && [ "$vimedit" = "yes" ]; then
         tmpf=$(mktemp /tmp/resty.XXXXXX)
         [ -t 0 ] || cat > $tmpf


### PR DESCRIPTION
I often find myself doing a PUT or a POST only specifying options - not specifying request body data at all.  This patch will only read from stdin if it's a pipe.

This does break the ability to just type in data when doing a POST, so maybe you're not okay with that.  If that's the case, this this could maybe be an option to PUT or POST?
