### PR TITLE
Use XDG directories when defined

### DIFF
--- a/resty
+++ b/resty
@@ -18,9 +18,14 @@ function resty() {
   local -a curlopt
   local -a curlopt2
 
-  confdir="${XDG_CONFIG_HOME}/resty"
+  if [ -n "$XDG_CONFIG_HOME" ]; then
+    confdir="$XDG_CONFIG_HOME/resty"
+    datadir="$XDG_DATA_HOME/resty"
+  else
+    confdir="$HOME/.resty"
+    datadir="$confdir"
+  fi
   mkdir -p "$confdir"
-  datadir="${XDG_DATA_HOME}/resty"
   host="$datadir/host"
   cookies="$datadir/c"
   method="$1"; [[ $# > 0 ]] && shift


### PR DESCRIPTION
These patches make resty default to using the XDG basedir spec by default.  Host files (e,g. `localhost:5984`) are stored in `$XDG_CONFIG_HOME/resty` whilst cookies and the host file are stored in `$XDG_DATA_HOME/resty`.  If `XDG_CONFIG_HOME` is undefined, the previous default of `$HOME/.resty` is used.
