### PR TITLE
antigen package manager

### DIFF
--- a/resty.plugin.zsh
+++ b/resty.plugin.zsh
@@ -1,0 +1,18 @@
+##########################################################
+#                                                        #
+#                ____            __                      #
+#               / __ \___  _____/ /___  __               #
+#              / /_/ / _ \/ ___/ __/ / / /               #
+#             / _, _/  __(__  ) /_/ /_/ /                #
+#            /_/ |_|\___/____/\__/\__, /                 #
+#                                /____/                  #
+#                                                        #
+##########################################################
+
+## Zsh Antigen installer for resty.
+
+source "$(dirname $0:A)/resty"
+alias pp="$(cat $(dirname $0:A)/pp)"
+alias pypp="$(cat $(dirname $0:A)/pypp)"
+
+# source file, and create alias with the content of pp, ppyp


### PR DESCRIPTION
Add a plugin.zsh file to permit resty to be install throught antigen (zsh plugin) manager.

Resty can be then installed adding `antigen bundle micha/resty` in one's `.zshrc` file (of course if already using [Antigen](https://github.com/zsh-users/antigen)