### PR TITLE
actually return 0 when $ret=2 and set -o pipefail

### DIFF
--- a/resty
+++ b/resty
@@ -102,6 +102,7 @@ function resty() {
         return $ret
       else
         [ -n "$out" ] && echo "$out"
+	return 0
       fi
       ;;
     http://*|https://*)


### PR DESCRIPTION
Without explicit `return 0` $methods return 1.