### PR TITLE
Indent parentheses properly for zsh (fix #61)

### DIFF
--- a/resty
+++ b/resty
@@ -29,9 +29,9 @@ function resty() {
   host="$datadir/host"
   cookies="$datadir/c"
   method="$1"; [[ $# > 0 ]] && shift
-  h2t=$((exec 2>&-; (which lynx >/dev/null && echo lynx -stdin -dump) \
+  h2t=$( (exec 2>&-; (which lynx >/dev/null && echo lynx -stdin -dump) \
                 || which html2text || which cat) |tail -n 1)
-  editor=$((exec 2>&-; which "$EDITOR" || which vim || echo "vi") |tail -n 1)
+  editor=$( (exec 2>&-; which "$EDITOR" || which vim || echo "vi") |tail -n 1)
   
   [ "${method#P}" != "$method" ] || [ "$method" = "TRACE" ] && wantdata="yes"
 
@@ -82,7 +82,7 @@ function resty() {
       [ -n "$dat" ] && opt="--data-binary"
       [ "$method" = "HEAD" ] && opt="-I" && raw="yes"
       [ -f "$confdir/$domain" ] && eval "args2=( $(cat "$confdir/$domain" 2>/dev/null |sed 's/^ *//' |grep ^$method |cut -b $((${#method}+2))-) )"
-      res=$((((curl -sLv $opt "$dat" -X $method \
+      res=$( ( ( (curl -sLv $opt "$dat" -X $method \
               -b "$cookies/$domain" -c "$cookies/$domain" \
               "${args2[@]}" "${curlopt2[@]}" "${curlopt[@]}" "$_path$query" \
         |sed 's/^/OUT /' && echo) 3>&2 2>&1 1>&3) \


### PR DESCRIPTION
Hi! I noticed the script does not work with zsh, so I took a look and found out that it uses consecutive opening parentheses, and zsh does not like that (and I agree, as it's not easy to parse `$(( foobar ))` vs `$(( foo ) | bar )` without backtracking).