### PR TITLE
Bugfix: don't grep through working dir in ZSH

### DIFF
--- a/resty
+++ b/resty
@@ -82,8 +82,8 @@ function resty() {
       [ "$1" = "-Z" ] && raw="yes" && [[ $# > 0 ]] && shift
       [ -n "$dat" ] && opt="--data-binary"
       [ "$method" = "HEAD" ] && opt="-I" && raw="yes"
-      [ -f "$confdir/$domain" ] && eval "args2=( $(cat "$confdir/$domain" 2>/dev/null |sed 's/^ *//' |grep ^$method |cut -b $((${#method}+2))-) )"
 
+      [ -f "$confdir/$domain" ] && eval "args2=( $(cat "$confdir/$domain" 2>/dev/null |sed 's/^ *//' |grep '^$method' |cut -b $((${#method}+2))-) )"
       [ "$dry" = "yes" ] && echo "curl -sLv $opt \"$dat\" -X $method -b "$cookies/$domain" -c "$cookies/$domain" \"${args2[@]}\" \"${curlopt2[@]}\" \"${curlopt[@]}\" \"$_path$query\"" && return 0
       # TODO: refactor function
       res=$( ( ( (curl -sLv $opt "$dat" -X $method \


### PR DESCRIPTION
In ZSH I got a bunch of
```
grep: database: Is a directory
grep: gems: Is a directory
grep: log: Is a directory
```
messages, as soon as I used a `$confdir/$domain` file. 