### PR TITLE
fixed grep parameter expansion

### DIFF
--- a/resty
+++ b/resty
@@ -83,7 +83,7 @@ function resty() {
       [ -n "$dat" ] && opt="--data-binary"
       [ "$method" = "HEAD" ] && opt="-I" && raw="yes"
 
-      [ -f "$confdir/$domain" ] && eval "args2=( $(cat "$confdir/$domain" 2>/dev/null |sed 's/^ *//' |grep '^$method' |cut -b $((${#method}+2))-) )"
+      [ -f "$confdir/$domain" ] && eval "args2=( $(cat "$confdir/$domain" 2>/dev/null |sed 's/^ *//' |grep "^$method" |cut -b $((${#method}+2))-) )"
       [ "$dry" = "yes" ] && echo "curl -sLv $opt \"$dat\" -X $method -b "$cookies/$domain" -c "$cookies/$domain" \"${args2[@]}\" \"${curlopt2[@]}\" \"${curlopt[@]}\" \"$_path$query\"" && return 0
       # TODO: refactor function
       res=$( ( ( (curl -sLv $opt "$dat" -X $method \


### PR DESCRIPTION
- issue: resty ignores configuration in ~/.resty
  - reason: expression in apostroph does not get expanded in bash nor in zsh
  - fix: replaced apostroph with quote
  - tested on bash and zsh
