### PR TITLE
Fix not storing cookies at first install

### DIFF
--- a/resty
+++ b/resty
@@ -53,6 +53,7 @@ HELP
         _RESTY_DATA_DIR="$_RESTY_CONF_DIR"
     fi
     mkdir -p "$_RESTY_CONF_DIR"
+    mkdir -p "$_RESTY_CONF_DIR/c"
 
     local host; host="$_RESTY_DATA_DIR/host"
 

--- a/resty
+++ b/resty
@@ -130,10 +130,6 @@ HELP
     local editor="$_RESTY_EDITOR"
     if [[ "POST PUT TRACE PATCH DELETE" =~ $method ]]; then local hasbody; hasbody="yes" ;fi
 
-    if [ -d "$cookies" ] ; then # retrieve cookie
-	    (mkdir -p "$cookies"; echo "http://localhost*" > "$host")
-    fi
-
     if [[ "$1" =~ ^/ ]] ; then # retrieve path
         _path="$1"
         shift


### PR DESCRIPTION
Not sure if I was doing something wrong but after
```
git clone git@github.com:micha/resty.git
. resty
resty HOST
GET /URL
```
The ~/.resty/c was not created and the cookies were not saved.
I had to create ~/.resty/c myself before the cookies were saved.

Also it looks like the previous code to create the cookie file only ran if the cookie file already exists and overwrote the host file (but not $_RESTY_HOST).