### PR TITLE
Make curl_opt local variable so it does not leak between requests

### DIFF
--- a/resty
+++ b/resty
@@ -130,7 +130,7 @@ HELP
     if [[ "POST PUT TRACE PATCH DELETE" =~ $method ]]; then local hasbody; hasbody="yes" ;fi
 
     if [ -d "$cookies" ] ; then # retrieve cookie
-	    (mkdir -p "$cookies"; echo "http://localhost*" > "$host")
+	    (mkdir -p "$cookies"; echo "http://localhost*" >| "$host")
     fi
 
     if [[ "$1" =~ ^/ ]] ; then # retrieve path
@@ -143,7 +143,7 @@ HELP
         [[ $# -gt 0 ]] && shift
     fi
 
-    local -a all_opts curlopt_cmd
+    local -a all_opts curl_opt curlopt_cmd
     local raw query vimedit quote maybe_query verbose dry_run
 
     local -a resty_default_arg host_arg;
@@ -199,7 +199,7 @@ HELP
 
     if [ "$hasbody" = "yes" ] && [ "$vimedit" = "yes" ]; then
         local tmpf; tmpf=$(mktemp)
-        [ -t 0 ] || cat > "$tmpf"
+        [ -t 0 ] || cat >| "$tmpf"
         (exec < /dev/tty; "$editor" "$tmpf")
         body=$(cat "$tmpf")
         rm -f "$tmpf"
@@ -213,8 +213,7 @@ HELP
     fi
 
     # Forge command and display it if dry-run
-    local cmd
-    cmd=(curl -sLv $curl_opt $(printf "%q" "$body") -X $method  -b \"$cookies/$domain\" -c \"$cookies/$domain\" "$(\
+    local cmd=(curl -sLv $curl_opt $(printf "%q" "$body") -X $method  -b \"$cookies/$domain\" -c \"$cookies/$domain\" "$(\
         [ -n "$curlopt_cmd" ] && printf '%s ' ${curlopt_cmd[@]})"\"$_path$query\")
     if [ "$dry_run" = "yes" ] ; then
         echo "${cmd[@]}"
@@ -224,9 +223,9 @@ HELP
     # Launch command and retrieved streams
     local res out err ret _status outf errf
     outf=$(mktemp) errf=$(mktemp)
-    eval "${cmd[@]}" > "$outf" 2> "$errf"
+    eval "${cmd[@]}" >| "$outf" 2>| "$errf"
     _status=$?; out="$(cat "$outf")"; err="$(cat "$errf")"; rm -f "$outf" "$errf"
-    ret=$(sed '/^.*HTTP\/1\.[01] [0-9][0-9][0-9]/s/.*\([0-9]\)[0-9][0-9].*/\1/p; d' <<< "$err" | tail -n1)
+    ret=$(sed '/^.*HTTP\/[12]\(\.[01]\)\? [0-9][0-9][0-9]/s/.*\([0-9]\)[0-9][0-9].*/\1/p; d' <<< "$err" | tail -n1)
 
     if [ "$_status" -ne "0" ]; then echo "$err" >&2 ; return $_status ; fi
 

--- a/resty
+++ b/resty
@@ -213,7 +213,7 @@ HELP
     fi
 
     # Forge command and display it if dry-run
-    local cmd=(curl -sLv $curl_opt $(printf "%q" "$body") -X $method  -b \"$cookies/$domain\" -c \"$cookies/$domain\" "$(\
+    local cmd=(curl -sLv $curl_opt $([ -n "$body" ] && printf "%q" "$body") -X $method  -b \"$cookies/$domain\" -c \"$cookies/$domain\" "$(\
         [ -n "$curlopt_cmd" ] && printf '%s ' ${curlopt_cmd[@]})"\"$_path$query\")
     if [ "$dry_run" = "yes" ] ; then
         echo "${cmd[@]}"


### PR DESCRIPTION
Fixing the scope of curl_opt so that it does not leak between requests. Before this fix, if you issue a HEAD and then a GET, you are still getting the `-I` parameter and causes the GET to be treated as a HEAD.

This includes the fixes from https://github.com/micha/resty/pull/80 and will wait for that to get merged (soon?) and then rebase mine.