### PR TITLE
remove link to screencast

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ to easily provide your own options to be passed directly to `curl`, so even
 the most complex requests can be accomplished with the minimum amount of
 command line pain.
 
-[Here is a nice screencast showing resty in action](http://jpmens.net/2010/04/26/resty/) (by Jan-Piet Mens).
-
 ## Quick Start
 
 You have `curl`, right? Okay.


### PR DESCRIPTION
It was brought to my attention today, that the screencast has been been removed from the source at screencast.com, so I updated by blog post accordingly. As such, I believe the link to my blog is no longer of interest in this README.