### PR TITLE
Export resty functions to subshells

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   - zsh ~/.zshrc
   - sh -c "export BINDIR=$HOME ; `curl -L https://raw.github.com/rylnd/shpec/master/install.sh`"
 
+  - chmod +x $HOME/.nvm/nvm.sh
   - $HOME/.nvm/nvm.sh
   - nvm install 6 && nvm use 6
   - (cd test && npm install)

--- a/resty
+++ b/resty
@@ -337,4 +337,26 @@ HELP
 # With -W option, does not write to history file
 [ "$1" = "-W" ] && export _RESTY_NO_HISTORY="/dev/null" && [[ $# -gt 0 ]] && shift
 
+# Force functions to be exported to subshells if it is supported
+case "$SHELL" in
+    */bash)
+        declare -fx \
+            resty \
+            resty-compute-host-option \
+            resty-call \
+            resty-load-alias \
+            resty-unload-alias \
+            resty-head \
+            resty-options \
+            resty-get \
+            resty-post \
+            resty-put \
+            resty-patch \
+            resty-delete \
+            resty-trace \
+            -resty-help-options 
+        ;;
+esac 
+
+
 resty "$@" >/dev/null 2>&1

--- a/resty
+++ b/resty
@@ -339,7 +339,7 @@ HELP
 
 # Force functions to be exported to subshells if it is supported
 case "$SHELL" in
-    */bash)
+    */bash|bash)
         declare -fx \
             resty \
             resty-compute-host-option \

--- a/test/resty_shpec.sh
+++ b/test/resty_shpec.sh
@@ -1,5 +1,21 @@
 [[ "$SHELL" == "bash" ]] && shopt -s expand_aliases # needed for bash
 
+RESTY_FUNCTIONS=()
+RESTY_FUNCTIONS+=(resty)
+RESTY_FUNCTIONS+=(resty-compute-host-option )
+RESTY_FUNCTIONS+=(resty-call)
+RESTY_FUNCTIONS+=(resty-load-alias)
+RESTY_FUNCTIONS+=(resty-unload-alias)
+RESTY_FUNCTIONS+=(resty-head)
+RESTY_FUNCTIONS+=(resty-options)
+RESTY_FUNCTIONS+=(resty-get)
+RESTY_FUNCTIONS+=(resty-post)
+RESTY_FUNCTIONS+=(resty-put)
+RESTY_FUNCTIONS+=(resty-patch)
+RESTY_FUNCTIONS+=(resty-delete)
+RESTY_FUNCTIONS+=(resty-trace)
+RESTY_FUNCTIONS+=(-resty-help-options )
+
 describe "Resty"
 
     describe "Basic"
@@ -24,6 +40,11 @@ describe "Resty"
         it "get the good content"
             output=$(GET /simple.txt)
             assert equal "$output" "hi there"
+        end
+
+        it "should work in a subshell"
+            exported_functions=$(bash -c "declare -F | grep $(printf " -e %s" ${RESTY_FUNCTIONS})" | wc -l)
+            assert equal "$exported_functions" "${#RESTY_FUNCTIONS}"
         end
 
     end

--- a/test/resty_shpec.sh
+++ b/test/resty_shpec.sh
@@ -44,7 +44,7 @@ describe "Resty"
 
         if [ "${SHELL}" == "bash" ]; then
             it "should work in a subshell"
-                exported_functions=$(bash -c "declare -F | grep $(printf " -e %s" ${RESTY_FUNCTIONS})" | wc -l)
+                exported_functions="$(printf "%d" $(bash -c "declare -F | grep $(printf " -e %s" ${RESTY_FUNCTIONS})" | wc -l))"
                 assert equal "$exported_functions" "${#RESTY_FUNCTIONS[@]}"
             end
         fi

--- a/test/resty_shpec.sh
+++ b/test/resty_shpec.sh
@@ -42,10 +42,12 @@ describe "Resty"
             assert equal "$output" "hi there"
         end
 
-        it "should work in a subshell"
-            exported_functions=$(bash -c "declare -F | grep $(printf " -e %s" ${RESTY_FUNCTIONS})" | wc -l)
-            assert equal "$exported_functions" "${#RESTY_FUNCTIONS[@]}"
-        end
+        if [ "${SHELL}" == "bash" ]; then
+            it "should work in a subshell"
+                exported_functions=$(bash -c "declare -F | grep $(printf " -e %s" ${RESTY_FUNCTIONS})" | wc -l)
+                assert equal "$exported_functions" "${#RESTY_FUNCTIONS[@]}"
+            end
+        fi
 
     end
 

--- a/test/resty_shpec.sh
+++ b/test/resty_shpec.sh
@@ -44,7 +44,7 @@ describe "Resty"
 
         it "should work in a subshell"
             exported_functions=$(bash -c "declare -F | grep $(printf " -e %s" ${RESTY_FUNCTIONS})" | wc -l)
-            assert equal "$exported_functions" "${#RESTY_FUNCTIONS}"
+            assert equal "$exported_functions" "${#RESTY_FUNCTIONS[@]}"
         end
 
     end


### PR DESCRIPTION
When a subshell is created the resty functions are not exported.

That patch fix the problem on bash shell, others shells can not have this kind of functionality.