### PR TITLE
Fix sed regex on OSX

### DIFF
--- a/resty
+++ b/resty
@@ -130,7 +130,7 @@ HELP
     if [[ "POST PUT TRACE PATCH DELETE" =~ $method ]]; then local hasbody; hasbody="yes" ;fi
 
     if [ -d "$cookies" ] ; then # retrieve cookie
-	    (mkdir -p "$cookies"; echo "http://localhost*" > "$host")
+	    (mkdir -p "$cookies"; echo "http://localhost*" >| "$host")
     fi
 
     if [[ "$1" =~ ^/ ]] ; then # retrieve path
@@ -199,7 +199,7 @@ HELP
 
     if [ "$hasbody" = "yes" ] && [ "$vimedit" = "yes" ]; then
         local tmpf; tmpf=$(mktemp)
-        [ -t 0 ] || cat > "$tmpf"
+        [ -t 0 ] || cat >| "$tmpf"
         (exec < /dev/tty; "$editor" "$tmpf")
         body=$(cat "$tmpf")
         rm -f "$tmpf"
@@ -224,7 +224,7 @@ HELP
     # Launch command and retrieved streams
     local res out err ret _status outf errf
     outf=$(mktemp) errf=$(mktemp)
-    eval "${cmd[@]}" > "$outf" 2> "$errf"
+    eval "${cmd[@]}" >| "$outf" 2>| "$errf"
     _status=$?; out="$(cat "$outf")"; err="$(cat "$errf")"; rm -f "$outf" "$errf"
     ret=$(sed '/^.*HTTP\/1\.[01] [0-9][0-9][0-9]/s/.*\([0-9]\)[0-9][0-9].*/\1/p; d' <<< "$err" | tail -n1)
 

--- a/resty
+++ b/resty
@@ -226,7 +226,7 @@ HELP
     outf=$(mktemp) errf=$(mktemp)
     eval "${cmd[@]}" >| "$outf" 2>| "$errf"
     _status=$?; out="$(cat "$outf")"; err="$(cat "$errf")"; rm -f "$outf" "$errf"
-    ret=$(sed '/^.*HTTP\/1\.[01] [0-9][0-9][0-9]/s/.*\([0-9]\)[0-9][0-9].*/\1/p; d' <<< "$err" | tail -n1)
+    ret=$(sed '/^.*HTTP\/[12]\(\.[01]\)\? [0-9][0-9][0-9]/s/.*\([0-9]\)[0-9][0-9].*/\1/p; d' <<< "$err" | tail -n1)
 
     if [ "$_status" -ne "0" ]; then echo "$err" >&2 ; return $_status ; fi
 

--- a/resty
+++ b/resty
@@ -143,7 +143,7 @@ HELP
         [[ $# -gt 0 ]] && shift
     fi
 
-    local -a all_opts curlopt_cmd
+    local -a all_opts curl_opt curlopt_cmd
     local raw query vimedit quote maybe_query verbose dry_run
 
     local -a resty_default_arg host_arg;
@@ -226,7 +226,7 @@ HELP
     outf=$(mktemp) errf=$(mktemp)
     eval "${cmd[@]}" >| "$outf" 2>| "$errf"
     _status=$?; out="$(cat "$outf")"; err="$(cat "$errf")"; rm -f "$outf" "$errf"
-    ret=$(sed '/^.*HTTP\/[12]\(\.[01]\)\? [0-9][0-9][0-9]/s/.*\([0-9]\)[0-9][0-9].*/\1/p; d' <<< "$err" | tail -n1)
+    ret=$(sed '/^.*HTTP\/[12].*/s/.* \([0-9]\)[0-9][0-9].*/\1/p; d' <<< "$err" | tail -n1)
 
     if [ "$_status" -ne "0" ]; then echo "$err" >&2 ; return $_status ; fi
 


### PR DESCRIPTION
regex that extracts HTTP return codes was not working on OSX sed, this new version works on both

took the opportunity to include fix from upstream repo [PR#82](https://github.com/micha/resty/pull/82)